### PR TITLE
Update installation.rst (Instructions for OS X)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,6 +63,10 @@ libspotify in the homebrew/binary tap::
 
     brew install homebrew/binary/libspotify
 
+Install libffi as a dependency::
+
+    brew install libffi
+
 .. warning::
 
    There's an issue with building pyspotify against libspotify on OS X where
@@ -71,7 +75,7 @@ libspotify in the homebrew/binary tap::
    A known workaround is to create a symlink after installing libspotify, but
    before installing pyspotify::
 
-       sudo ln -s /usr/local/opt/libspotify/lib/libspotify.12.1.51.dylib \
+       ln -s /usr/local/opt/libspotify/lib/libspotify.12.1.51.dylib \
        /usr/local/opt/libspotify/lib/libspotify
 
    Alternatively, the mopidy/mopidy Homebrew tap has a libspotify formula which


### PR DESCRIPTION
Removes `sudo` on creating a libspotify symlink since /usr/local is user-accessible.
Adds `brew install libffi` since it's required to compile pyspotify.